### PR TITLE
evm_interpreter::eval::macros made public

### DIFF
--- a/interpreter/src/eval/macros.rs
+++ b/interpreter/src/eval/macros.rs
@@ -1,122 +1,168 @@
-macro_rules! try_or_fail {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__try_or_fail {
 	($e:expr) => {
 		match $e {
 			Ok(v) => v,
-			Err(e) => return Control::Exit(e.into()),
+			Err(e) => return $crate::etable::Control::Exit(e.into()),
 		}
 	};
 }
+#[doc(inline)]
+pub use __eval__macros__try_or_fail as try_or_fail;
 
-macro_rules! pop {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__pop {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
 			let $x = match $machine.stack.pop() {
 				Ok(value) => value,
-				Err(e) => return Control::Exit(e.into()),
+				Err(e) => return $crate::etable::Control::Exit(e.into()),
 			};
 		)*
 	);
 }
+#[doc(inline)]
+pub use __eval__macros__pop as pop;
 
-macro_rules! pop_u256 {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__pop_u256 {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
 			let $x = match $machine.stack.pop() {
 				Ok(value) => U256::from_big_endian(&value[..]),
-				Err(e) => return Control::Exit(e.into()),
+				Err(e) => return $crate::etable::Control::Exit(e.into()),
 			};
 		)*
 	);
 }
+#[doc(inline)]
+pub use __eval__macros__pop_u256 as pop_u256;
 
-macro_rules! push {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__push {
 	( $machine:expr, $( $x:expr ),* ) => (
 		$(
 			match $machine.stack.push($x) {
 				Ok(()) => (),
-				Err(e) => return Control::Exit(e.into()),
+				Err(e) => return $crate::etable::Control::Exit(e.into()),
 			}
 		)*
 	)
 }
+#[doc(inline)]
+pub use __eval__macros__push as push;
 
-macro_rules! push_u256 {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__push_u256 {
 	( $machine:expr, $( $x:expr ),* ) => (
 		$(
 			let mut value = H256::default();
 			$x.to_big_endian(&mut value[..]);
 			match $machine.stack.push(value) {
 				Ok(()) => (),
-				Err(e) => return Control::Exit(e.into()),
+				Err(e) => return $crate::etable::Control::Exit(e.into()),
 			}
 		)*
 	)
 }
+#[doc(inline)]
+pub use __eval__macros__push_u256 as push_u256;
 
-macro_rules! op1_u256_fn {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__op1_u256_fn {
 	($machine:expr, $op:path) => {{
-		pop_u256!($machine, op1);
+		$crate::eval::macros::pop_u256!($machine, op1);
 		let ret = $op(op1);
-		push_u256!($machine, ret);
+		$crate::eval::macros::push_u256!($machine, ret);
 
-		Control::Continue
+		$crate::etable::Control::Continue
 	}};
 }
+#[doc(inline)]
+pub use __eval__macros__op1_u256_fn as op1_u256_fn;
 
-macro_rules! op2_u256_bool_ref {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__op2_u256_bool_ref {
 	($machine:expr, $op:ident) => {{
-		pop_u256!($machine, op1, op2);
+		$crate::eval::macros::pop_u256!($machine, op1, op2);
 		let ret = op1.$op(&op2);
-		push_u256!($machine, if ret { U256::one() } else { U256::zero() });
+		$crate::eval::macros::push_u256!($machine, if ret { U256::one() } else { U256::zero() });
 
-		Control::Continue
+		$crate::etable::Control::Continue
 	}};
 }
+#[doc(inline)]
+pub use __eval__macros__op2_u256_bool_ref as op2_u256_bool_ref;
 
-macro_rules! op2_u256 {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__op2_u256 {
 	($machine:expr, $op:ident) => {{
-		pop_u256!($machine, op1, op2);
+		$crate::eval::macros::pop_u256!($machine, op1, op2);
 		let ret = op1.$op(op2);
-		push_u256!($machine, ret);
+		$crate::eval::macros::push_u256!($machine, ret);
 
-		Control::Continue
+		$crate::etable::Control::Continue
 	}};
 }
+#[doc(inline)]
+pub use __eval__macros__op2_u256 as op2_u256;
 
-macro_rules! op2_u256_tuple {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__op2_u256_tuple {
 	($machine:expr, $op:ident) => {{
-		pop_u256!($machine, op1, op2);
+		$crate::eval::macros::pop_u256!($machine, op1, op2);
 		let (ret, ..) = op1.$op(op2);
-		push_u256!($machine, ret);
+		$crate::eval::macros::push_u256!($machine, ret);
 
-		Control::Continue
+		$crate::etable::Control::Continue
 	}};
 }
+#[doc(inline)]
+pub use __eval__macros__op2_u256_tuple as op2_u256_tuple;
 
-macro_rules! op2_u256_fn {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__op2_u256_fn {
 	($machine:expr, $op:path) => {{
-		pop_u256!($machine, op1, op2);
+		$crate::eval::macros::pop_u256!($machine, op1, op2);
 		let ret = $op(op1, op2);
-		push_u256!($machine, ret);
+		$crate::eval::macros::push_u256!($machine, ret);
 
-		Control::Continue
+		$crate::etable::Control::Continue
 	}};
 }
+#[doc(inline)]
+pub use __eval__macros__op2_u256_fn as op2_u256_fn;
 
-macro_rules! op3_u256_fn {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__op3_u256_fn {
 	($machine:expr, $op:path) => {{
-		pop_u256!($machine, op1, op2, op3);
+		$crate::eval::macros::pop_u256!($machine, op1, op2, op3);
 		let ret = $op(op1, op2, op3);
-		push_u256!($machine, ret);
+		$crate::eval::macros::push_u256!($machine, ret);
 
-		Control::Continue
+		$crate::etable::Control::Continue
 	}};
 }
+#[doc(inline)]
+pub use __eval__macros__op3_u256_fn as op3_u256_fn;
 
-macro_rules! as_usize_or_fail {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __eval__macros__as_usize_or_fail {
 	($v:expr) => {{
 		if $v > U256::from(usize::MAX) {
-			return Control::Exit(ExitFatal::NotSupported.into());
+			return $crate::etable::Control::Exit(ExitFatal::NotSupported.into());
 		}
 
 		$v.as_usize()
@@ -124,9 +170,11 @@ macro_rules! as_usize_or_fail {
 
 	($v:expr, $reason:expr) => {{
 		if $v > U256::from(usize::MAX) {
-			return Control::Exit($reason.into());
+			return $crate::etable::Control::Exit($reason.into());
 		}
 
 		$v.as_usize()
 	}};
 }
+#[doc(inline)]
+pub use __eval__macros__as_usize_or_fail as as_usize_or_fail;

--- a/interpreter/src/eval/misc.rs
+++ b/interpreter/src/eval/misc.rs
@@ -1,3 +1,4 @@
+use super::macros::*;
 use super::Control;
 use crate::utils::u256_to_h256;
 use crate::{ExitError, ExitException, ExitFatal, ExitSucceed, Machine};

--- a/interpreter/src/eval/mod.rs
+++ b/interpreter/src/eval/mod.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-mod macros;
+pub mod macros;
 mod arithmetic;
 mod bitwise;
 mod misc;
@@ -10,6 +9,7 @@ use crate::{
 	RuntimeBackend, RuntimeEnvironment, RuntimeState, TrapConstruct,
 };
 use core::ops::{BitAnd, BitOr, BitXor};
+use macros::*;
 use primitive_types::{H256, U256};
 
 pub fn eval_pass<S, H, Tr>(

--- a/interpreter/src/eval/system.rs
+++ b/interpreter/src/eval/system.rs
@@ -1,3 +1,4 @@
+use super::macros::*;
 use super::Control;
 use crate::{
 	ExitException, ExitFatal, ExitSucceed, GasState, Log, Machine, RuntimeBackend,


### PR DESCRIPTION
Building docs for evm errors out with `broken_intra_doc_links`, but it's not my doing. interpreter docs compile just fine.